### PR TITLE
fix: correct unkown to unknown typo in any.js

### DIFF
--- a/any.js
+++ b/any.js
@@ -64,13 +64,13 @@ module.exports = function (codex) {
     },
     encodingLength: function (value, buffer, start, end) {
       var codec = map[value[type_field.name]]
-      if(!codec) throw new Error('unkown codec. tag='+ value[type_field.name])
+      if(!codec) throw new Error('unknown codec. tag='+ value[type_field.name])
      return codec.encodingLength(value, buffer, start, end)
     },
     encodedLength: function (buffer, start, end) {
       var tvalue = decodeType(buffer, start, end)
       var codec = map[tvalue]
-      if(!codec) throw new Error('unkown codec. tag='+ tvalue)
+      if(!codec) throw new Error('unknown codec. tag='+ tvalue)
       return codec.encodedLength(buffer, start, end)
     },
   }


### PR DESCRIPTION
Fix typo: `unkown` → `unknown` in any.js error messages (lines 67, 73).

The throw statements now display the correct spelling of 'unknown' when a codec error occurs.

Signed-off-by: Jah-yee <166608075+Jah-yee@users.noreply.github.com>